### PR TITLE
Fix test

### DIFF
--- a/seppi-project/server.js
+++ b/seppi-project/server.js
@@ -1156,16 +1156,86 @@ router.route('/register')
 router.route('/login')
   .post();
 
-router.route('/userInfo')
-    .post();
-
 router.route('/changeEmail')
-     .post();
+	.post();
+
+router.route('/resendEmailVerification')
+	.post();
+
+router.route('/searchRecipe')
+	.post();
+
+router.route('/addIngredient')
+	.post();
+
+router.route('/removeIngredient')
+	.post();
+
+router.route('/editIngredient')
+	.post();
+
+router.route('/addCategory')
+	.post();
+
+router.route('/removeCategory')
+	.post();
+
+router.route('/getCategories')
+	.post();
+
+router.route('/deleteIngredient')
+	.post();
+
+router.route('/getGrocery')
+	.post();
+
+router.route('/deleteGrocery')
+	.post();
+
+router.route('/addGrocery')
+	.post();
+
+router.route('/addGroceryArray')
+	.post();
+
+router.route('/updateGrocery')
+	.post();
+
+router.route('/lookupBarcode')
+	.post();
+
+router.route('/getExpiringIngredients')
+	.post();
+
+
+router.route('/getUser')
+	.post();
+
+router.route('/changeDisplayName')
+	.post();
+
+router.route('/userInfo')
+	.post();
+
+router.route('/userSet')
+	.post();
+
+router.route('/addFavorite')
+	.post();
+
+router.route('/getFavorites')
+	.post();
+
+router.route('/removeFavorite')
+    .post();
 
 router.route('/signout')
     .post();
 
 router.route('/resetPassword')
+	.post();
+
+router.route('/signout')
     .post();
 
 const server = app.listen(port, () => {

--- a/seppi-project/server.js
+++ b/seppi-project/server.js
@@ -71,10 +71,10 @@ app.post('/register', (req, res) => {
       diet: '',
     });
 
-    return res.status(200).send(JSON.stringify({response:"Register successful email verification sent to " + req.body.email}));
+    return res.status(200).json({response:"Register successful email verification sent to " + req.body.email, status:200});
   })
   .catch(function(error) {
-    return res.status(400).send(JSON.stringify({response:error.message}));
+    return res.status(400).json({response:error.message, status: 400});
   });
 
 
@@ -93,12 +93,12 @@ app.post('/register', (req, res) => {
                       console.log("email not verified resending email");
 
                       user.sendEmailVerification().then(function() {
-                          return res.status(401).send(JSON.stringify({response:"email not verified"}));
+                          return res.status(401).json({response: 'email not verified', status: 401});
 
                  }).catch(function(error) {
                    // An error happened.
                    // this probably happens from too many requests to send email verification
-                   return res.status(401).send(JSON.stringify({response:error}));
+                   return res.status(401).json({response:error.message, status: 401});
                  });
 
                   }
@@ -121,7 +121,7 @@ app.post('/register', (req, res) => {
                   // user not signed in
                 } else {
                   // No user is signed in.
-                    return res.status(400).send(JSON.stringify({response:"No User"}));
+                    return res.status(400).json({response:"No User", status: 400});
                 }
           }
           // catches when sign in has problems.
@@ -129,22 +129,27 @@ app.post('/register', (req, res) => {
         // Handle Errors here.
         var errorCode = error.code;
         var errorMessage = error.message;
-        return res.status(400).send(JSON.stringify({response:error.message}));
+        return res.status(400).json({response:error.message, status: 400});
      });
  }
 
   });
 
   app.post('/resetPassword', (req, res) => {
-      var auth = firebase.auth();
+    
+    var auth = firebase.auth();
+    var emailAddress = "";
+    if (req.body.email !== undefined)
+    {
+      emailAddress = req.body.email.replace(/[|&;$%"<>()+,]/g, "");
+    }
 
-    var emailAddress = req.body.email;
 
     auth.sendPasswordResetEmail(emailAddress).then(function() {
-        return res.status(200).send(JSON.stringify({response:"email ver sent"}));
+        return res.status(200).json({response:"email ver sent", status: 200});
         // Email sent.
   }).catch(function(error) {
-      return res.status(400).send(JSON.stringify({response:error}));
+      return res.status(400).json({response: error.message, status: 400});
 
   })
 });

--- a/seppi-project/server.test.js
+++ b/seppi-project/server.test.js
@@ -34,14 +34,14 @@ test('Login User with correct credentials and verified email', async () => {
     expect(res.body.email).toBe("lap65222@cuoly.com")
 });
 
-test.skip('Login User with correct credentials with an unverified email', async () => {
+test('Login User with correct credentials with an unverified email', async () => {
     const res = await request(server).post('/login').send({"email":"jagoh46664@idcbill.com", "password":"!^$b$fN6moHRE&@XjRW6iL"})
 
     expect(res.status).toBe(401) // 401 = Unauthorized
     expect(res.body.response).toBe("email not verified")
 });
 
-test.skip('Login User with incorrect credentials', async () => {
+test('Login User with incorrect credentials', async () => {
     const res = await request(server).post('/login').send({"email":"sflap65222@cuoly.com", "password":"sdfs8xkI7cX$oJUnT5fzp3D!xj"})
 
     expect(res.status).toBe(400) // 400 = Bad Request
@@ -56,14 +56,14 @@ test('Login User with bad fields', async () => {
 
 //test.todo('Forgot Password Endpoint');
 
-test.skip('Forgot Password on a valid account', async () => {
+test('Forgot Password on a valid account', async () => {
     const res = await request(server).post('/resetPassword').send({"email":"lap65222@cuoly.com", "password":"sdfs8xkI7cX$oJUnT5fzp3D!xj"})
 
     expect(res.status).toBe(200)
     expect(res.body.response).toBe("email ver sent")
 });
 
-test.skip('Forgot Password on a nonexsistant account', async () => {
+test('Forgot Password on a nonexsistant account', async () => {
     const res = await request(server).post('/resetPassword').send({"email":"sdfsfsfjagoh46664@idcbill.com"})
 
     expect(res.status).toBe(400)
@@ -79,7 +79,7 @@ test('Forgot Password with bad fields', async () => {
 //test.todo('Change User Email Endpoint');
 
 
-test.skip('Change email with valid email', async () => {
+test('Change email with valid email', async () => {
     const res = await request(server).post('/resetPassword').send({"email":"lap65222@cuoly.com"})
 
     expect(res.status).toBe(200)
@@ -101,7 +101,7 @@ test('Change email with bad fields', async () => {
 
 //test.todo('Create User Endpoint');
 
-test.skip('Create user with all valid info', async () => {
+test('Create user with all valid info', async () => {
     // Generates a random 7 digit string
     let prefix = Math.random().toString(36).substring(7)
     let password = Math.random().toString(36).substring(7)

--- a/seppi-project/server.test.js
+++ b/seppi-project/server.test.js
@@ -57,7 +57,7 @@ test('Login User with bad fields', async () => {
 //test.todo('Forgot Password Endpoint');
 
 test('Forgot Password on a valid account', async () => {
-    const res = await request(server).post('/resetPassword').send({"email":"lap65222@cuoly.com", "password":"sdfs8xkI7cX$oJUnT5fzp3D!xj"})
+    const res = await request(server).post('/resetPassword').send({"email":"lap65222@cuoly.com"})
 
     expect(res.status).toBe(200)
     expect(res.body.response).toBe("email ver sent")
@@ -67,13 +67,13 @@ test('Forgot Password on a nonexsistant account', async () => {
     const res = await request(server).post('/resetPassword').send({"email":"sdfsfsfjagoh46664@idcbill.com"})
 
     expect(res.status).toBe(400)
-    expect(res.body.response.message).toBe("There is no user record corresponding to this identifier. The user may have been deleted.")
+    expect(res.body.response).toBe("There is no user record corresponding to this identifier. The user may have been deleted.")
 });
 
 test('Forgot Password with bad fields', async () => {
     const res = await request(server).post('/resetPassword').send({"notAnEmail":"sdfsfsfjagoh46664@idcbill.com"})
 
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(400)
 });
 
 //test.todo('Change User Email Endpoint');
@@ -95,21 +95,21 @@ test('Change email with invalid email', async () => {
 test('Change email with bad fields', async () => {
     const res = await request(server).post('/resetPassword').send({"notAnEmail":"sdsfdsfsfsffsfsfjagoh46664@idcbill.com"})
 
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(400)
 });
 
 
 //test.todo('Create User Endpoint');
 
-test('Create user with all valid info', async () => {
+test.skip('Create user with all valid info', async () => {
     // Generates a random 7 digit string
     let prefix = Math.random().toString(36).substring(7)
     let password = Math.random().toString(36).substring(7)
     let email = prefix + "@idcbill.com"
-    const res = await request(server).post('/register').send({"email": email, "password": password})
+    const res = await request(server).post('/register').send({"name": prefix, "email": email, "password": password})
 
-    expect(res.status).toBe(400)
-    expect(res.body.response).toBe({response:"Register successful email verification sent to " + email})
+    expect(res.status).toBe(200)
+    expect(res.body.response).toBe("Register successful email verification sent to " + email)
 });
 
 test('Create user with bad fields', async () => {


### PR DESCRIPTION
server-side code double encodes the text string and causes the test to fail

for example
```
   "status":400,
   "text":"{\"response\":{\"code\":\"auth/user-not-found\",\"message\":\"There is no user record corresponding to this identifier. The user may have been deleted.\"}}"
}
```